### PR TITLE
Add buildNumber to pdxinfo

### DIFF
--- a/pdxinfo
+++ b/pdxinfo
@@ -2,5 +2,6 @@ name=Playtris
 author=@thacuber2a03
 description=It's some random tetromino game for the Playdate console. And that's about it.
 version=1.5.1
+buildNumber=5
 imagePath=launcher
 bundleID=com.thacuber.tetris


### PR DESCRIPTION
This is important as the Playdate determines whether to update based on this number. Currently, if a player has a previous version of Playtris, then sideloads the latest version, it will not automatically update. Instead, the player must uninstall and reinstall Playtris.

I've chosen the number 5 simply because 1.5.1 is the 5th version published to this repo. We would increase it to buildNumber=6 or any higher integer at next release ([it's recommended](https://sdk.play.date/1.11.0/Inside%20Playdate.html#pdxinfo) that a formal build pipeline be established that automates this number increasing but I personally don't feel strongly about that)

Final note: requesting pull into main because dev is behind main- don't forget to catch dev up when hotfixing!