### PR TITLE
Add menu image to obscure playfield and also show more info while paused

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -966,13 +966,15 @@ bgmIntro:play()
 
 function playdate.gameWillPause()
 	
-	local img = gfx.image.new(dwidth, dheight, darkMode and gfx.kColorBlack or gfx.kColorWhite)
+	local img = gfx.image.new(dwidth, dheight, gfx.kColorWhite)
 	local text = "Score\n" .. math.floor(score) .. "\nHighscore\n" .. highscore .. "\nLevel\n" .. level .. "\nLines\n" .. completedLines
 	
 	gfx.lockFocus(img)
 	gfx.setFont(bold)
 	gfx.drawTextAligned(text, dwidth/4, 42, kTextAlignment.center)
 	gfx.unlockFocus()
+
+	img:setInverted(darkMode)
 
 	playdate.setMenuImage(img)
 

--- a/main.lua
+++ b/main.lua
@@ -555,7 +555,6 @@ local function updateGame()
 end
 
 local function drawScores()
-	local bold = gfx.getSystemFont("bold")
 	gfx.drawTextAligned("*Score*", (UITimer.value-2)*uiBlockSize, 9*uiBlockSize, kTextAlignment.center)
 	gfx.drawTextAligned("*"..math.floor(score).."*", (UITimer.value-2)*uiBlockSize, 11*uiBlockSize, kTextAlignment.center)
 	gfx.drawTextAligned("*Highscore*", (UITimer.value-2)*uiBlockSize, 13*uiBlockSize, kTextAlignment.center)
@@ -563,8 +562,6 @@ local function drawScores()
 end
 
 local function drawLevelInfo()
-	local bold = gfx.getSystemFont("bold")
-
 	gfx.drawTextAligned("*Level*", dwidth-(UITimer.value-2)*uiBlockSize, 9*uiBlockSize,kTextAlignment.center)
 	gfx.drawTextAligned("*"..level.."*", dwidth-(UITimer.value-2)*uiBlockSize, 11*uiBlockSize,kTextAlignment.center)
 	gfx.drawTextAligned("*Lines*", dwidth-(UITimer.value-2)*uiBlockSize, 13*uiBlockSize, kTextAlignment.center)
@@ -929,7 +926,6 @@ sysmenu:addMenuItem("options", function()
 		menuOpen = not menuOpen
 		if not menuOpen then closeMenu()
 		else
-			bold = gfx.getSystemFont("bold")
 			menuYTimer = time.new(250, 0, dheight/2, easings.outBack)
 			menuHeight = #menu*bold:getHeight()
 			local longestString = ""

--- a/main.lua
+++ b/main.lua
@@ -964,6 +964,20 @@ end)
 
 bgmIntro:play()
 
+function playdate.gameWillPause()
+	
+	local img = gfx.image.new(dwidth, dheight, darkMode and gfx.kColorBlack or gfx.kColorWhite)
+	local text = "Score\n" .. math.floor(score) .. "\nHighscore\n" .. highscore .. "\nLevel\n" .. level .. "\nLines\n" .. completedLines
+	
+	gfx.lockFocus(img)
+	gfx.setFont(bold)
+	gfx.drawTextAligned(text, dwidth/4, 42, kTextAlignment.center)
+	gfx.unlockFocus()
+
+	playdate.setMenuImage(img)
+
+end
+
 function playdate.update()
 	if not bgmIntro:isPlaying() and not bgmLoop:isPlaying() then
 		bgmLoop:play(0)


### PR DESCRIPTION
<img width="800" alt="Screen Shot 2022-05-11 at 8 57 08 PM" src="https://user-images.githubusercontent.com/6517535/167980351-3cbe9f40-7411-49e7-a530-ac377c5a4fac.png">

Nice and simple, if you want to get fancier with the design go for it!

Note: Marking as draft until dev is up to date- it will look like there are lots more changes than there are until then, making it harder to review