### PR TITLE
Added ability to rotate pieces via crank, fixed "shake" and "ghost" settings bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pdx
 *.zip
 support/*
+.vscode

--- a/src/globals.lua
+++ b/src/globals.lua
@@ -7,7 +7,7 @@ savedData = DATA.read("gamedata") or {}
 function loadData(key, defaultValue)
 	local saved = savedData[key]
 	if saved == nil then
-		return default
+		return defaultValue
 	end
 
 	return saved

--- a/src/globals.lua
+++ b/src/globals.lua
@@ -4,7 +4,15 @@ import "constants"
 -- If there's no game DATA available make some
 savedData = DATA.read("gamedata") or {}
 
-function loadData(key) return savedData[key] end
+function loadData(key, defaultValue)
+	local saved = savedData[key]
+	if saved == nil then
+		return default
+	end
+
+	return saved
+end
+
 function saveData(key, value) savedData[key] = value end
 
 function commitSaveData()
@@ -31,12 +39,12 @@ maxLockDelayRotations = 15
 	bigBlocks,
 	chill_mode
 =
-	loadData("shake") or true, loadData("sash") or true, loadData("ghost") or true,
-	loadData("grid") or false, loadData("darkMode") or false,
-	loadData("inverseRotation") or false,
-	loadData("music") or 1, loadData("sounds") or 1,
-	loadData("bigBlocks") or false,
-	loadData("chill_mode") or false
+	loadData("shake", true), loadData("sash", true), loadData("ghost", true),
+	loadData("grid", false), loadData("darkMode", false),
+	loadData("inverseRotation", false),
+	loadData("music", 1), loadData("sounds", 1),
+	loadData("bigBlocks", false),
+	loadData("chill_mode", false)
 
 if bigBlocks then
 	blockSize = bigBlockSize

--- a/src/main.lua
+++ b/src/main.lua
@@ -22,6 +22,7 @@
 
 import "CoreLibs/graphics"
 import "CoreLibs/timer"
+import "CoreLibs/crank"
 
 import "globals"
 import "utils"
@@ -216,6 +217,25 @@ local function rotate(rotation)
 
 	updateGhost()
 	spinSound:play()
+end
+
+local function handleCrankRotation()
+	local ticksPerRevolution = 4
+	local tick = PD.getCrankTicks(ticksPerRevolution)
+
+	if tick == 0 then
+		return
+	end
+
+	if piece.type == OPIECE then
+		return
+	end
+
+	if inverseRotation then
+		tick *= -1
+	end
+
+	rotate(tick)
 end
 
 local function resetLockDelay()
@@ -475,6 +495,8 @@ function updateGame()
 		if PD.buttonIsPressed("right") then holdDirection(1)
 		elseif PD.buttonIsPressed("left") then holdDirection(-1)
 		else holdDir = 0 end
+
+		handleCrankRotation()
 
 		local current, _, released = PD.getButtonState()
 		if current == (PD.kButtonA | PD.kButtonB) and not heldBothButtons then

--- a/src/pdxinfo
+++ b/src/pdxinfo
@@ -1,7 +1,7 @@
 name=BlockDate
 author=@thacuber2a03
 description=It's some random tetromino game for the Playdate console (themed edition)
-version=2.3
-buildNumber=16
+version=2.4
+buildNumber=17
 imagePath=launcher
 bundleID=com.thacuber.playtris

--- a/src/pdxinfo
+++ b/src/pdxinfo
@@ -1,7 +1,7 @@
 name=BlockDate
 author=@thacuber2a03
 description=It's some random tetromino game for the Playdate console (themed edition)
-version=2.4
-buildNumber=17
+version=2.3
+buildNumber=16
 imagePath=launcher
 bundleID=com.thacuber.playtris

--- a/src/pdxinfo
+++ b/src/pdxinfo
@@ -1,7 +1,7 @@
 name=BlockDate
 author=@thacuber2a03
 description=It's some random tetromino game for the Playdate console (themed edition)
-version=2.2
-buildNumber=15
+version=2.3
+buildNumber=16
 imagePath=launcher
 bundleID=com.thacuber.playtris


### PR DESCRIPTION
Added ability to rotate pieces via crank
Added .vscode settings directory to gitignore

Note: Crank rotation is handled in `updateGame()` instead of an input handler like a/b rotation because there is no input handler equivalent to `playdate.getCrankTicks()`